### PR TITLE
fix(seaweedfs): Fix the bug of fetching up to 100 files at a time

### DIFF
--- a/crawlab-base/install/seaweedfs/seaweedfs.sh
+++ b/crawlab-base/install/seaweedfs/seaweedfs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-wget https://github.com/crawlab-team/resources/raw/main/seaweedfs/2.79/linux_amd64.tar.gz \
+wget https://github.com/seaweedfs/seaweedfs/releases/download/3.47/linux_amd64.tar.gz \
   && tar -zxf linux_amd64.tar.gz \
   && cp weed /usr/local/bin


### PR DESCRIPTION
背景：
seaweedfs在3.44版本修复了一个前端UI一页不超过100个文件的bug
https://github.com/seaweedfs/seaweedfs/issues/4258

crawlab在调用seaweedfs接口获取文件时也遇到了这个bug，一次性获取最多100个文件


描述：
将seaweedfs升级到3.44及其之后的版本
本地测试安装seaweedfs 3.44及其之后的版本可一次性获取最多1000个文件

其他解决措施：
修改goseaweedfs客户端的代码，支持分页参数，当获取超过100个文件时，进行分页查询获取

